### PR TITLE
Left Aligned Subject and Removed Hardcoded Server Names

### DIFF
--- a/lib/pages/email_list.dart
+++ b/lib/pages/email_list.dart
@@ -260,15 +260,18 @@ class _EmailListPageState extends State<EmailListPage> {
                                   )
                               ],
                             ),
-                            Text(subject.trim(),
-                                maxLines: 1,
-                                style: TextStyle(
-                                  fontSize: 12,
-                                  color: themeNotifier.isDarkMode
-                                      ? Colors.white
-                                      : Colors.black,
-                                ),
-                                overflow: TextOverflow.ellipsis),
+                            Align(
+                              alignment: Alignment.centerLeft,
+                              child: Text(subject.trim(),
+                                  maxLines: 1,
+                                  style: TextStyle(
+                                    fontSize: 12,
+                                    color: themeNotifier.isDarkMode
+                                        ? Colors.white
+                                        : Colors.black,
+                                  ),
+                                  overflow: TextOverflow.ellipsis),
+                            ),
                             Text(
                               normalizeSpaces(body),
                               style: TextStyle(

--- a/lib/pages/forward_screen.dart
+++ b/lib/pages/forward_screen.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:iitk_mail_client/EmailCache/models/email.dart';
 import 'package:iitk_mail_client/services/forward_mail.dart';
 import 'package:iitk_mail_client/services/snackbar_navigate.dart';
-
+import 'package:provider/provider.dart';
+import '../models/advanced_settings_model.dart';
 class ForwardEmailPage extends StatefulWidget {
   final Email email;
   final String username;
@@ -51,8 +52,11 @@ class _ForwardEmailPageState extends State<ForwardEmailPage> {
     setState(() {
       _isLoading = true;
     });
+     final emailSettings =
+        Provider.of<EmailSettingsModel>(context, listen: false);
 
     await EmailForward.forwardEmail(
+      emailSettings: emailSettings,
       username: widget.username,
       password: widget.password,
       originalMessage: widget.email,

--- a/lib/pages/reply_screen.dart
+++ b/lib/pages/reply_screen.dart
@@ -3,7 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:iitk_mail_client/EmailCache/models/email.dart';
 import 'package:iitk_mail_client/services/reply_mail.dart';
 import 'package:iitk_mail_client/services/snackbar_navigate.dart';
-
+import 'package:provider/provider.dart';
+import '../models/advanced_settings_model.dart';
 class ReplyEmailPage extends StatefulWidget {
   final Email email;
   final String username;
@@ -50,8 +51,10 @@ class _ReplyEmailPageState extends State<ReplyEmailPage> {
     setState(() {
       _isLoading = true;
     });
-
+     final emailSettings =
+        Provider.of<EmailSettingsModel>(context, listen: false);
     await EmailReply.replyEmail(
+      emailSettings: emailSettings,
       username: widget.username,
       password: widget.password,
       originalMessage: widget.email,

--- a/lib/services/forward_mail.dart
+++ b/lib/services/forward_mail.dart
@@ -1,10 +1,12 @@
 import 'package:enough_mail/enough_mail.dart';
 import 'package:flutter/material.dart';
 import 'package:iitk_mail_client/EmailCache/models/email.dart';
+import 'package:iitk_mail_client/models/advanced_settings_model.dart';
 import 'package:iitk_mail_client/services/email_fetch.dart';
 
 class EmailForward {
   static Future<void> forwardEmail({
+    required EmailSettingsModel emailSettings,
     required String username,
     required String password,
     required Email originalMessage,
@@ -12,9 +14,11 @@ class EmailForward {
     required String forwardBody,
     required Function(String, Color) onResult,
   }) async {
+    final String serverName = emailSettings.smtpServer;
+    final int port = int.parse(emailSettings.smtpPort); 
     final client = SmtpClient('enough_mail', isLogEnabled: true);
     try {
-      await client.connectToServer('mmtp.iitk.ac.in', 465, isSecure: true);
+      await client.connectToServer(serverName, port, isSecure: port == 465);
       await client.ehlo();
 
       await client.authenticate(username, password, AuthMechanism.plain);
@@ -26,7 +30,7 @@ class EmailForward {
 
       final builder = MessageBuilder.prepareForwardMessage(
         originalMimeMessage,
-        from: MailAddress(username, '$username@iitk.ac.in'),
+        from: MailAddress(username, '$username@${emailSettings.domain}'),
         forwardHeaderTemplate: 'Forwarded message',
         // quoteMessage: true,
         // subjectEncoding: HeaderEncoding.Q,

--- a/lib/services/reply_mail.dart
+++ b/lib/services/reply_mail.dart
@@ -1,11 +1,13 @@
 import 'package:enough_mail/enough_mail.dart';
 import 'package:flutter/material.dart';
 import 'package:iitk_mail_client/EmailCache/models/email.dart';
+import 'package:iitk_mail_client/models/advanced_settings_model.dart';
 import 'package:iitk_mail_client/services/email_fetch.dart';
 import 'package:iitk_mail_client/services/save_mails_to_objbox.dart';
 
 class EmailReply {
   static Future<void> replyEmail({
+    required EmailSettingsModel emailSettings,
     required String username,
     required String password,
     required Email originalMessage,
@@ -13,9 +15,11 @@ class EmailReply {
     required Function(String, Color) onResult,
   }) async {
     logger.i('Starting replyEmail function');
+    final String serverName = emailSettings.smtpServer;
+    final int port = int.parse(emailSettings.smtpPort);
     final client = SmtpClient('enough_mail', isLogEnabled: false);
     try {
-      await client.connectToServer('mmtp.iitk.ac.in', 465, isSecure: true);
+      await client.connectToServer(serverName, port, isSecure: port == 465);
       await client.ehlo();
       logger.i('Connected and authenticated');
 
@@ -28,7 +32,7 @@ class EmailReply {
       logger.i(originalMimeMessage);
       final builder = MessageBuilder.prepareReplyToMessage(
         originalMimeMessage,
-        MailAddress(username, '$username@iitk.ac.in'),
+        MailAddress(username, '$username@${emailSettings.domain}'),
       );
       final originalBody = originalMessage.body;
       final newBody = "$replyBody\n\n----Original Message----\n\n$originalBody";


### PR DESCRIPTION
I aligned the subject in the mail view page to the left. 
Also, I removed the hardcoded server and port names in email forward and reply pages. Rather I used the email settings model to provide the names.