### PR TITLE
fixed "from" ui and made email body text copyable

### DIFF
--- a/lib/pages/compose_mail_page.dart
+++ b/lib/pages/compose_mail_page.dart
@@ -149,7 +149,7 @@ class _ComposeEmailPageState extends State<ComposeEmailPage> {
                 Row(
               children: [
                 SizedBox(
-                  width: 50,
+                  width: 70,
                   child: Text(
                     'From:',
                     style: TextStyle(

--- a/lib/pages/email_view_page.dart
+++ b/lib/pages/email_view_page.dart
@@ -325,7 +325,7 @@ class _EmailViewPageState extends State<EmailViewPage> {
                 const Divider(color: Colors.grey),
               ],
               const SizedBox(height: 8),
-              Text(
+              SelectableText(
                 body,
                 style: theme.textTheme.bodyMedium?.copyWith(
                   color: theme.brightness == Brightness.dark


### PR DESCRIPTION
the from part when we use to compose mail had a very bad ui were the colon was not in front of "from " text . before user could not copy the text  form body part of the email so just changed the "Text" widget to "SelectableText " widget so now user can copy the text